### PR TITLE
ordering for chars and strings

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,11 @@
 # Changelog for PiG
 
+### 0.10.0
+* '==', '!=', '>' and '<' working for every type except for lambdas
+
+### 0.9.0
+* chars and strings
+
 ### 0.8.0
 * reworked type system with more flexible operators and less boilerplate
 

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                PiG
-version:             0.9.0
+version:             0.10.0
 github:              PKopel/PiG
 license:             BSD3
 author:              Paweł Kopel

--- a/src/Lang/Lexer.hs
+++ b/src/Lang/Lexer.hs
@@ -149,7 +149,11 @@ listOperators =
 
 eqOperators :: [[Operator Char st Expr]]
 eqOperators =
-  [ [ Infix (reservedOp "==" >> return (Binary ((==) :: Val -> Val -> Bool)))
+  [ [ Infix (reservedOp ">" >> return (Binary ((>) :: Val -> Val -> Bool)))
+            AssocLeft
+    , Infix (reservedOp "<" >> return (Binary ((<) :: Val -> Val -> Bool)))
+            AssocLeft
+    , Infix (reservedOp "==" >> return (Binary ((==) :: Val -> Val -> Bool)))
             AssocLeft
     , Infix (reservedOp "!=" >> return (Binary ((/=) :: Val -> Val -> Bool)))
             AssocLeft

--- a/src/Utils/Types.hs
+++ b/src/Utils/Types.hs
@@ -70,6 +70,11 @@ instance BinAppToVal (Double -> Double -> Bool) where
   appBin op (AlgVal a) (AlgVal b) = BoolVal $ op a b
   appBin _  _          _          = Null
 
+instance BinAppToVal (String -> String -> Bool) where
+  appBin op (StrVal  a) (StrVal  b) = BoolVal $ op a b
+  appBin op (CharVal a) (CharVal b) = BoolVal $ op [a] [b]
+  appBin _  _           _           = Null
+
 instance BinAppToVal (Double -> Double -> Double) where
   appBin op (AlgVal a) (AlgVal b) = AlgVal $ op a b
   appBin _  _          _          = Null
@@ -113,6 +118,11 @@ instance Eq Expr where
   (Val v1) == (Val v2) = v1 == v2
   _        == _        = False
 
+instance Ord Expr where
+  (Var v1) <= (Var v2) = v1 <= v2
+  (Val v1) <= (Val v2) = v1 <= v2
+  _        <= _        = False
+
 data Val
   = AlgVal Double
   | BoolVal Bool
@@ -121,7 +131,7 @@ data Val
   | ListVal (Seq Val)
   | FunVal [Var] Expr
   | Null
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Show Val where
   show (AlgVal  v    ) = show v


### PR DESCRIPTION
'>' and '<' now work for all types except for lambdas