### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -132,6 +132,8 @@ jobs:
     needs: [build, provenance]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: write
     steps:
       - name: Download linux binary
         uses: actions/download-artifact@v4.3.0


### PR DESCRIPTION
Potential fix for [https://github.com/PKopel/PiG/security/code-scanning/3](https://github.com/PKopel/PiG/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the `release` job in the workflow file. The permissions should be limited to the minimum required for the job to function correctly. Based on the actions performed in the `release` job (downloading artifacts and uploading release assets), the following permissions are necessary:
- `contents: read` to download artifacts.
- `contents: write` to upload release assets.

The `permissions` block should be added directly under the `release` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
