### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: write
     outputs:
       hash-linux: ${{ steps.hash.outputs.hash }}
       hash-macos: ${{ steps.hash-mac.outputs.hash }}


### PR DESCRIPTION
Potential fix for [https://github.com/PKopel/PiG/security/code-scanning/2](https://github.com/PKopel/PiG/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the `build` job in the workflow. This block will specify the minimal permissions required for the job to function correctly. Based on the steps in the `build` job, the following permissions are appropriate:
- `contents: read` for checking out the code and reading repository contents.
- `contents: write` for uploading artifacts.

The `permissions` block will be added directly under the `build` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
