### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,5 +1,8 @@
 name: Unit tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/PKopel/PiG/security/code-scanning/1](https://github.com/PKopel/PiG/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow to function correctly. Since the workflow only checks out the repository and builds/tests the code, it only needs `contents: read` permission. This ensures that the `GITHUB_TOKEN` used in the workflow has minimal access.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
